### PR TITLE
Port to 0.9.0

### DIFF
--- a/Loader/loader.lua
+++ b/Loader/loader.lua
@@ -57,7 +57,7 @@ end
 
 local function getFolderTree(baseFolder)
   local tree = {__folder = baseFolder}
-  for i,v in ipairs(love.filesystem.enumerate(baseFolder)) do
+  for i,v in ipairs(love.filesystem.getDirectoryItems(baseFolder)) do
     if love.filesystem.isDirectory(baseFolder..v) then
       tree[v] = getFolderTree(baseFolder..v..'/')
     end
@@ -155,7 +155,7 @@ function loader.init()
   
     -- Custom *.ttf font loading 
     loader.extFont = {}
-    foreach(love.filesystem.enumerate(DefaultBaseExternalFontPath), function(_,font)
+    foreach(love.filesystem.getDirectoryItems(DefaultBaseExternalFontPath), function(_,font)
     local f = font:match('(.+)%.ttf$')
       if f then
         loader.extFont[f] = setmetatable({__fontFile = font},baseExtFontMetatable)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 __love2d-assets-loader__ is a library for assets loading on demand.
-It works with [Löve2D](http://love2d.org) framework (compatible with Löve __0.8.0__).
+It works with [Löve2D](http://love2d.org) framework (compatible with Löve __0.9.0__).
 The aim of this utility is to simplify in-game assets (fonts, audio, images) loading and management.
 
 __love2d-assets-loader__ have been highy inspired by [Vrld](https://github.com/vrld/)'s [Proxy](https://github.com/vrld/Princess/blob/master/main.lua) function.


### PR DESCRIPTION
Really simple to port to 0.9.0. Just replaces love.filesystem.enumerate() with love.filesystem.getDirectoryItems().
