### PR TITLE
Fixes compatibility issue with 0.9 and small README change

### DIFF
--- a/Loader/loader.lua
+++ b/Loader/loader.lua
@@ -55,9 +55,17 @@ local function getFilePath(fileName,basePath,validFormats)
   end
 end
 
+local function getDirectoryItems(directory)
+  if love.filesystem.enumerate then
+    return love.filesystem.enumerate(directory)
+  else
+    return love.filesystem.getDirectoryItems(directory)
+  end
+end
+
 local function getFolderTree(baseFolder)
   local tree = {__folder = baseFolder}
-  for i,v in ipairs(love.filesystem.enumerate(baseFolder)) do
+  for i,v in ipairs(getDirectoryItems(baseFolder)) do
     if love.filesystem.isDirectory(baseFolder..v) then
       tree[v] = getFolderTree(baseFolder..v..'/')
     end
@@ -155,7 +163,7 @@ function loader.init()
   
     -- Custom *.ttf font loading 
     loader.extFont = {}
-    foreach(love.filesystem.enumerate(DefaultBaseExternalFontPath), function(_,font)
+    foreach(getDirectoryItems(DefaultBaseExternalFontPath), function(_,font)
     local f = font:match('(.+)%.ttf$')
       if f then
         loader.extFont[f] = setmetatable({__fontFile = font},baseExtFontMetatable)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 __love2d-assets-loader__ is a library for assets loading on demand.
-It works with [Löve2D](http://love2d.org) framework (compatible with Löve __0.8.0__).
+It works with [Löve2D](http://love2d.org) framework (compatible with Löve __0.8.0__ and __0.9.x__).
 The aim of this utility is to simplify in-game assets (fonts, audio, images) loading and management.
 
 __love2d-assets-loader__ have been highy inspired by [Vrld](https://github.com/vrld/)'s [Proxy](https://github.com/vrld/Princess/blob/master/main.lua) function.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ __love2d-assets-loader__ have been highy inspired by [Vrld](https://github.com/v
 * Loads [.png](http://en.wikipedia.org/wiki/PNG), [.jpg](https://en.wikipedia.org/wiki/JPEG) and [.bmp](http://en.wikipedia.org/wiki/BMP_file_format) [images](https://love2d.org/wiki/Image)
 
 ##Installation
-Put the file [loader.lua](https://github.com/Yonaba/love2d-assets-loader/blob/master/Loader/loader.lua) inside your project folder.<br/>
+Put the file [loader.lua](https://raw.githubusercontent.com/Yonaba/love2d-assets-loader/master/Loader/loader.lua) inside your project folder.<br/>
 Call it using the __require__ function.<br/>
 It will return a reference to the public interface as a regular Lua table.
 


### PR DESCRIPTION
Without this change, the following exception is raised:

Error: loader.lua:161: attempt to call field 'enumerate' (a nil value)
stack traceback:
    loader.lua:161: in function 'init'
    main.lua:9: in function 'load'
    [string "boot.lua"]:406: in function <[string "boot.lua"]:399>
    [C]: in function 'xpcall'

This is due to incompatibility between older versions and current 0.9 release.

Also included a couple of minor README changes
